### PR TITLE
Refactor

### DIFF
--- a/src/provstor/cli.py
+++ b/src/provstor/cli.py
@@ -74,7 +74,7 @@ def load(crate, fuseki_url, fuseki_dataset):
     RO_CRATE: RO-Crate directory or ZIP archive.
     """
     crate_url = load_crate_metadata(crate, fuseki_url, fuseki_dataset)
-    sys.stdout.write(f"Crate URL: {crate_url}\n")
+    sys.stdout.write(f"{crate_url}\n")
 
 
 @cli.command()
@@ -110,7 +110,7 @@ def query(query_file, fuseki_url, fuseki_dataset, graph):
     query = query_file.read_text()
     qres = run_query(query, fuseki_url, fuseki_dataset, graph)
     for row in qres:
-        sys.stdout.write(f"{row}\n")
+        sys.stdout.write(", ".join(row) + "\n")
 
 
 @cli.command()

--- a/src/provstor/queries.py
+++ b/src/provstor/queries.py
@@ -26,6 +26,17 @@ WHERE {
 }
 """
 
+# The parameter must be replaced by a root data entity id
+CRATE_URL_QUERY = """\
+PREFIX schema: <http://schema.org/>
+
+SELECT ?crate_url
+WHERE {
+  <%s> schema:url ?crate_url
+}
+"""
+
+
 GRAPH_ID_FOR_FILE_QUERY = """\
 PREFIX schema: <http://schema.org/>
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,12 +26,6 @@ THIS_DIR = Path(__file__).absolute().parent
 DATA_DIR_NAME = 'data'
 
 
-# pytest's tmpdir returns a py.path object
-@pytest.fixture
-def tmpdir(tmpdir):
-    return Path(tmpdir)
-
-
 @pytest.fixture(scope="session")
 def data_dir():
     return THIS_DIR / DATA_DIR_NAME

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,10 @@
 
 from pathlib import Path
 
+import arcp
 import pytest
+
+from provstor.load import load_crate_metadata
 
 
 THIS_DIR = Path(__file__).absolute().parent
@@ -29,6 +32,20 @@ def tmpdir(tmpdir):
     return Path(tmpdir)
 
 
-@pytest.fixture
-def data_dir(tmpdir):
+@pytest.fixture(scope="session")
+def data_dir():
     return THIS_DIR / DATA_DIR_NAME
+
+
+@pytest.fixture(scope="session")
+def crate_map(data_dir):
+    m = {}
+    for c in "crate1", "crate2", "provcrate1":
+        crate_path = data_dir / c
+        crate_url = load_crate_metadata(crate_path)
+        m[c] = {
+            "path": crate_path,
+            "url": crate_url,
+            "rde_id": arcp.arcp_location(crate_url)
+        }
+    return m

--- a/tests/data/query.txt
+++ b/tests/data/query.txt
@@ -1,6 +1,6 @@
 PREFIX schema: <http://schema.org/>
 
-SELECT ?name
+SELECT ?person ?name
 WHERE {
   ?person a schema:Person .
   ?person schema:name ?name

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,10 +23,10 @@ from provstor.constants import MINIO_STORE, MINIO_BUCKET
 
 
 @pytest.mark.parametrize("zipped", [False, True])
-def test_cli_load(data_dir, tmpdir, zipped):
+def test_cli_load(data_dir, tmp_path, zipped):
     runner = CliRunner()
     if zipped:
-        crate = shutil.make_archive(tmpdir / "crate1", "zip", data_dir / "crate1")
+        crate = shutil.make_archive(tmp_path / "crate1", "zip", data_dir / "crate1")
     else:
         crate = data_dir / "crate1"
     args = ["load", str(crate)]
@@ -55,32 +55,32 @@ def test_cli_query(graph, crate_map, data_dir):
 
 
 @pytest.mark.parametrize("cwd", [False, True])
-def test_cli_get_crate(crate_map, tmpdir, monkeypatch, cwd):
+def test_cli_get_crate(crate_map, tmp_path, monkeypatch, cwd):
     runner = CliRunner()
     rde_id = crate_map["crate1"]["rde_id"]
     if cwd:
-        monkeypatch.chdir(str(tmpdir))
+        monkeypatch.chdir(str(tmp_path))
         args = ["get-crate", rde_id]
     else:
-        args = ["get-crate", rde_id, "-o", tmpdir]
+        args = ["get-crate", rde_id, "-o", tmp_path]
     result = runner.invoke(cli, args)
     assert result.exit_code == 0, result.exception
-    assert (tmpdir / "crate1.zip").is_file()
+    assert (tmp_path / "crate1.zip").is_file()
 
 
 @pytest.mark.parametrize("cwd", [False, True])
-def test_cli_get_file(crate_map, tmpdir, monkeypatch, cwd):
+def test_cli_get_file(crate_map, tmp_path, monkeypatch, cwd):
     runner = CliRunner()
     rde_id = crate_map["crate1"]["rde_id"]
     file_id = rde_id + "ro-crate-metadata.json"
     if cwd:
-        monkeypatch.chdir(str(tmpdir))
+        monkeypatch.chdir(str(tmp_path))
         args = ["get-file", file_id]
     else:
-        args = ["get-file", file_id, "-o", tmpdir]
+        args = ["get-file", file_id, "-o", tmp_path]
     result = runner.invoke(cli, args)
     assert result.exit_code == 0, result.exception
-    assert (tmpdir / "ro-crate-metadata.json").is_file()
+    assert (tmp_path / "ro-crate-metadata.json").is_file()
 
 
 def test_cli_get_graph_id(crate_map):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,6 @@
 
 import shutil
 
-import arcp
 from click.testing import CliRunner
 import pytest
 from provstor.cli import cli

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,20 +55,30 @@ def test_cli_query(graph, crate_map, data_dir):
         }
 
 
-def test_cli_get_crate(crate_map, tmpdir):
+@pytest.mark.parametrize("cwd", [False, True])
+def test_cli_get_crate(crate_map, tmpdir, monkeypatch, cwd):
     runner = CliRunner()
     rde_id = crate_map["crate1"]["rde_id"]
-    args = ["get-crate", rde_id, "-o", tmpdir]
+    if cwd:
+        monkeypatch.chdir(str(tmpdir))
+        args = ["get-crate", rde_id]
+    else:
+        args = ["get-crate", rde_id, "-o", tmpdir]
     result = runner.invoke(cli, args)
     assert result.exit_code == 0, result.exception
     assert (tmpdir / "crate1.zip").is_file()
 
 
-def test_cli_get_file(crate_map, tmpdir):
+@pytest.mark.parametrize("cwd", [False, True])
+def test_cli_get_file(crate_map, tmpdir, monkeypatch, cwd):
     runner = CliRunner()
     rde_id = crate_map["crate1"]["rde_id"]
     file_id = rde_id + "ro-crate-metadata.json"
-    args = ["get-file", file_id, "-o", tmpdir]
+    if cwd:
+        monkeypatch.chdir(str(tmpdir))
+        args = ["get-file", file_id]
+    else:
+        args = ["get-file", file_id, "-o", tmpdir]
     result = runner.invoke(cli, args)
     assert result.exit_code == 0, result.exception
     assert (tmpdir / "ro-crate-metadata.json").is_file()

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -32,14 +32,14 @@ from provstor.get import (
 
 
 @pytest.mark.parametrize("cwd", [False, True])
-def test_get_crate(crate_map, tmpdir, monkeypatch, cwd):
+def test_get_crate(crate_map, tmp_path, monkeypatch, cwd):
     crate_path = crate_map["crate1"]["path"]
     md_path = crate_path / "ro-crate-metadata.json"
     if cwd:
-        monkeypatch.chdir(str(tmpdir))
+        monkeypatch.chdir(str(tmp_path))
         zip_path = get_crate(crate_map["crate1"]["rde_id"])
     else:
-        zip_path = get_crate(crate_map["crate1"]["rde_id"], outdir=tmpdir)
+        zip_path = get_crate(crate_map["crate1"]["rde_id"], outdir=tmp_path)
     assert zip_path.name == "crate1.zip"
     with zipfile.ZipFile(zip_path, "r") as zipf:
         assert zipf.namelist() == ["ro-crate-metadata.json"]
@@ -47,15 +47,15 @@ def test_get_crate(crate_map, tmpdir, monkeypatch, cwd):
 
 
 @pytest.mark.parametrize("cwd", [False, True])
-def test_get_file(crate_map, tmpdir, monkeypatch, cwd):
+def test_get_file(crate_map, tmp_path, monkeypatch, cwd):
     crate_path = crate_map["crate1"]["path"]
     md_path = crate_path / "ro-crate-metadata.json"
     rde_id = crate_map["crate1"]["rde_id"]
     if cwd:
-        monkeypatch.chdir(str(tmpdir))
+        monkeypatch.chdir(str(tmp_path))
         out_md_path = get_file(f"{rde_id}/ro-crate-metadata.json")
     else:
-        out_md_path = get_file(f"{rde_id}/ro-crate-metadata.json", outdir=tmpdir)
+        out_md_path = get_file(f"{rde_id}/ro-crate-metadata.json", outdir=tmp_path)
     assert filecmp.cmp(out_md_path, md_path)
 
 

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -27,56 +27,40 @@ from provstor.get import (
     get_run_objects,
     get_run_params
 )
-from provstor.load import load_crate_metadata
-from provstor.queries import RDE_QUERY
-from provstor.query import run_query
 
 
-def _load_and_get_rde_id(crate_path):
-    crate_url = load_crate_metadata(crate_path)
-    qres = run_query(RDE_QUERY, graph_id=crate_url)
-    assert len(qres) == 1
-    return str(list(qres)[0][0])
-
-
-def test_get_crate(data_dir, tmpdir):
-    crate_path = data_dir / "crate1"
+def test_get_crate(crate_map, tmpdir):
+    crate_path = crate_map["crate1"]["path"]
     md_path = crate_path / "ro-crate-metadata.json"
-    rde_id = _load_and_get_rde_id(crate_path)
-    zip_path = get_crate(rde_id, outdir=tmpdir)
+    zip_path = get_crate(crate_map["crate1"]["rde_id"], outdir=tmpdir)
     assert zip_path.name == "crate1.zip"
     with zipfile.ZipFile(zip_path, "r") as zipf:
         assert zipf.namelist() == ["ro-crate-metadata.json"]
         assert zipf.read("ro-crate-metadata.json") == md_path.read_bytes()
 
 
-def test_get_file(data_dir, tmpdir):
-    crate_path = data_dir / "crate1"
+def test_get_file(crate_map, tmpdir):
+    crate_path = crate_map["crate1"]["path"]
     md_path = crate_path / "ro-crate-metadata.json"
-    rde_id = _load_and_get_rde_id(crate_path)
+    rde_id = crate_map["crate1"]["rde_id"]
     out_md_path = get_file(f"{rde_id}/ro-crate-metadata.json", outdir=tmpdir)
     assert filecmp.cmp(out_md_path, md_path)
 
 
-def test_get_graph_id(data_dir):
-    crate_path = data_dir / "provcrate1"
-    _load_and_get_rde_id(crate_path)
+def test_get_graph_id(crate_map):
     graph_id = get_graph_id("file:///path/to/FOOBAR123.md.cram")
     assert graph_id == f"http://{MINIO_STORE}/{MINIO_BUCKET}/provcrate1.zip"
 
 
-def test_get_workflow(data_dir):
-    crate_path = data_dir / "provcrate1"
-    rde_id = _load_and_get_rde_id(crate_path)
-    graph_id = f"http://{MINIO_STORE}/{MINIO_BUCKET}/provcrate1.zip"
+def test_get_workflow(crate_map):
+    graph_id = crate_map["provcrate1"]["url"]
+    rde_id = crate_map["provcrate1"]["rde_id"]
     workflow = get_workflow(graph_id)
     assert workflow == f"{rde_id}main.nf"
 
 
-def test_get_run_results(data_dir):
-    crate_path = data_dir / "provcrate1"
-    _load_and_get_rde_id(crate_path)
-    graph_id = f"http://{MINIO_STORE}/{MINIO_BUCKET}/provcrate1.zip"
+def test_get_run_results(crate_map):
+    graph_id = crate_map["provcrate1"]["url"]
     results = set(get_run_results(graph_id))
     assert results == {
         "file:///path/to/FOOBAR123.md.cram.crai",
@@ -84,10 +68,9 @@ def test_get_run_results(data_dir):
     }
 
 
-def test_get_run_objects(data_dir):
-    crate_path = data_dir / "provcrate1"
-    rde_id = _load_and_get_rde_id(crate_path)
-    graph_id = f"http://{MINIO_STORE}/{MINIO_BUCKET}/provcrate1.zip"
+def test_get_run_objects(crate_map):
+    graph_id = crate_map["provcrate1"]["url"]
+    rde_id = crate_map["provcrate1"]["rde_id"]
     objects = set(get_run_objects(graph_id))
     assert objects == {
         "file:///path/to/FOOBAR123_1.fastq.gz",
@@ -98,10 +81,8 @@ def test_get_run_objects(data_dir):
     }
 
 
-def test_get_run_params(data_dir):
-    crate_path = data_dir / "provcrate1"
-    _load_and_get_rde_id(crate_path)
-    graph_id = f"http://{MINIO_STORE}/{MINIO_BUCKET}/provcrate1.zip"
+def test_get_run_params(crate_map):
+    graph_id = crate_map["provcrate1"]["url"]
     params = set(get_run_params(graph_id))
     assert params == {
         ("input", "sample.csv"),

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -16,8 +16,6 @@
 
 from rdflib.term import Literal, URIRef
 
-from provstor.constants import MINIO_STORE, MINIO_BUCKET
-from provstor.load import load_crate_metadata
 from provstor.query import run_query
 
 PERSON_QUERY = """\
@@ -31,14 +29,11 @@ WHERE {
 """
 
 
-def test_run_query(data_dir, tmpdir):
+def test_run_query(crate_map):
 
     def check_results(exp_results, graph_id=None):
         qres = run_query(PERSON_QUERY, graph_id=graph_id)
         assert list(qres) == exp_results
-
-    for c in "crate1", "crate2":
-        load_crate_metadata(data_dir / c)
 
     check_results([
         (URIRef("https://orcid.org/0000-0001-8271-5429"), Literal("Simone Leo")),
@@ -49,4 +44,4 @@ def test_run_query(data_dir, tmpdir):
     ], graph_id="crate1")
     check_results([
         (URIRef("https://orcid.org/0000-0002-1825-0097"), Literal("Josiah Carberry"))
-    ], graph_id=f"http://{MINIO_STORE}/{MINIO_BUCKET}/crate2.zip")
+    ], graph_id=crate_map["crate2"]["url"])


### PR DESCRIPTION
* `get*` functions: use `run_query`
* Tests: use a session-scoped fixture that preloads the test crates