### PR TITLE
Update queries and functions

### DIFF
--- a/src/provstor/backtrack.py
+++ b/src/provstor/backtrack.py
@@ -1,0 +1,26 @@
+# Copyright © 2024-2025 CRS4
+#
+# This file is part of ProvStor.
+#
+# ProvStor is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# ProvStor is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ProvStor. If not, see <https://www.gnu.org/licenses/>.
+
+from .get import get_objects_for_result
+
+
+def backtrack(result_id):
+    objects = list(get_objects_for_result(result_id))
+    if objects:
+        yield objects
+        for obj in objects:
+            for r_obj in backtrack(obj):
+                yield r_obj

--- a/src/provstor/cli.py
+++ b/src/provstor/cli.py
@@ -26,6 +26,7 @@ from .get import (
     get_crate as get_crate_f,
     get_file as get_file_f,
     get_graphs_for_file as get_graphs_for_file_f,
+    get_graphs_for_result as get_graphs_for_result_f,
     get_run_results as get_run_results_f,
     get_run_objects as get_run_objects_f,
     get_run_params as get_run_params_f,
@@ -144,6 +145,23 @@ def get_graphs_for_file(file_id):
     FILE_ID: full URI of the file (e.g. file://...).
     """
     graphs = get_graphs_for_file_f(file_id)
+    for g in graphs:
+        sys.stdout.write(f"{g}\n")
+
+
+@cli.command()
+@click.argument(
+    "result_id",
+    metavar="RESULT_ID"
+)
+def get_graphs_for_result(result_id):
+    """\
+    Get the ids of the graphs where the given id is listed as the result of a
+    CreateAction.
+
+    RESULT_ID: RO-Crate id of the result.
+    """
+    graphs = get_graphs_for_result_f(result_id)
     for g in graphs:
         sys.stdout.write(f"{g}\n")
 

--- a/src/provstor/cli.py
+++ b/src/provstor/cli.py
@@ -173,12 +173,15 @@ def get_graphs_for_result(result_id):
 )
 def get_workflow(graph_id):
     """\
-    Get the workflow id corresponding to the given graph id.
+    Get the workflow id corresponding to the given graph id. This should
+    give a result only for a Workflow RO-Crate and crates whose profile is
+    derived from Workflow-RO-Crate.
 
     GRAPH_ID: id of the graph in the triple store.
     """
-    workflow = get_workflow_f(graph_id)
-    sys.stdout.write(f"{workflow}\n")
+    workflows = get_workflow_f(graph_id)
+    for g in workflows:
+        sys.stdout.write(f"{g}\n")
 
 
 @cli.command()

--- a/src/provstor/cli.py
+++ b/src/provstor/cli.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import click
 
 from . import __version__
+from .backtrack import backtrack as backtrack_f
 from .get import (
     get_crate as get_crate_f,
     get_file as get_file_f,
@@ -260,6 +261,21 @@ def list_graphs():
     graphs = list_graphs_f()
     for g in graphs:
         sys.stdout.write(f"{g}\n")
+
+
+@cli.command()
+@click.argument(
+    "result_id",
+    metavar="RESULT_ID"
+)
+def backtrack(result_id):
+    """\
+    Recursively get objects related to the given result by a chain of actions.
+
+    RESULT_ID: id of the result item.
+    """
+    for item in backtrack_f(result_id):
+        sys.stdout.write(f"{item}\n")
 
 
 @cli.command()

--- a/src/provstor/cli.py
+++ b/src/provstor/cli.py
@@ -30,6 +30,7 @@ from .get import (
     get_run_results as get_run_results_f,
     get_run_objects as get_run_objects_f,
     get_run_params as get_run_params_f,
+    get_objects_for_result as get_objects_for_result_f,
     get_workflow as get_workflow_f
 )
 from .list import list_graphs as list_graphs_f
@@ -214,6 +215,22 @@ def get_run_objects(graph_id):
     GRAPH_ID: id of the graph in the triple store.
     """
     objects = get_run_objects_f(graph_id)
+    for r in objects:
+        sys.stdout.write(f"{r}\n")
+
+
+@cli.command()
+@click.argument(
+    "result_id",
+    metavar="RESULT_ID"
+)
+def get_objects_for_result(result_id):
+    """\
+    Get objects that are related to the given result in a CreateAction.
+
+    RESULT_ID: id of the result item.
+    """
+    objects = get_objects_for_result_f(result_id)
     for r in objects:
         sys.stdout.write(f"{r}\n")
 

--- a/src/provstor/cli.py
+++ b/src/provstor/cli.py
@@ -25,7 +25,7 @@ from . import __version__
 from .get import (
     get_crate as get_crate_f,
     get_file as get_file_f,
-    get_graph_id as get_graph_id_f,
+    get_graphs_for_file as get_graphs_for_file_f,
     get_run_results as get_run_results_f,
     get_run_objects as get_run_objects_f,
     get_run_params as get_run_params_f,
@@ -137,14 +137,15 @@ def get_file(file_uri, outdir):
     "file_id",
     metavar="FILE_ID"
 )
-def get_graph_id(file_id):
+def get_graphs_for_file(file_id):
     """\
-    Get the graph id corresponding to the given file.
+    Get the ids of the graphs that contain (hasPart) the given file.
 
     FILE_ID: full URI of the file (e.g. file://...).
     """
-    graph_id = get_graph_id_f(file_id)
-    sys.stdout.write(f"{graph_id}\n")
+    graphs = get_graphs_for_file_f(file_id)
+    for g in graphs:
+        sys.stdout.write(f"{g}\n")
 
 
 @cli.command()

--- a/src/provstor/get.py
+++ b/src/provstor/get.py
@@ -89,9 +89,7 @@ def get_graphs_for_result(file_id):
 
 def get_workflow(graph_id):
     qres = run_query(WORKFLOW_QUERY, graph_id=graph_id)
-    assert len(qres) >= 1
-    workflow = str(list(qres)[0][0])
-    return workflow
+    return (str(_[0]) for _ in qres)
 
 
 def get_run_results(graph_id):

--- a/src/provstor/get.py
+++ b/src/provstor/get.py
@@ -28,9 +28,9 @@ from .queries import (
     CRATE_URL_QUERY,
     GRAPH_ID_FOR_FILE_QUERY,
     WORKFLOW_QUERY,
-    RUN_RESULTS_QUERY,
-    RUN_OBJECTS_QUERY,
-    RUN_PARAMS_QUERY
+    WFRUN_RESULTS_QUERY,
+    WFRUN_OBJECTS_QUERY,
+    WFRUN_PARAMS_QUERY
 )
 from .query import run_query
 
@@ -91,15 +91,15 @@ def get_workflow(graph_id):
 
 
 def get_run_results(graph_id):
-    qres = run_query(RUN_RESULTS_QUERY, graph_id=graph_id)
+    qres = run_query(WFRUN_RESULTS_QUERY, graph_id=graph_id)
     return (str(_[0]) for _ in qres)
 
 
 def get_run_objects(graph_id):
-    qres = run_query(RUN_OBJECTS_QUERY, graph_id=graph_id)
+    qres = run_query(WFRUN_OBJECTS_QUERY, graph_id=graph_id)
     return (str(_[0]) for _ in qres)
 
 
 def get_run_params(graph_id):
-    qres = run_query(RUN_PARAMS_QUERY, graph_id=graph_id)
+    qres = run_query(WFRUN_PARAMS_QUERY, graph_id=graph_id)
     return ((str(_.name), str(_.value)) for _ in qres)

--- a/src/provstor/get.py
+++ b/src/provstor/get.py
@@ -31,6 +31,7 @@ from .queries import (
     WORKFLOW_QUERY,
     WFRUN_RESULTS_QUERY,
     WFRUN_OBJECTS_QUERY,
+    OBJECTS_FOR_RESULT_QUERY,
     WFRUN_PARAMS_QUERY
 )
 from .query import run_query
@@ -99,6 +100,11 @@ def get_run_results(graph_id):
 
 def get_run_objects(graph_id):
     qres = run_query(WFRUN_OBJECTS_QUERY, graph_id=graph_id)
+    return (str(_[0]) for _ in qres)
+
+
+def get_objects_for_result(result_id):
+    qres = run_query(OBJECTS_FOR_RESULT_QUERY % result_id)
     return (str(_[0]) for _ in qres)
 
 

--- a/src/provstor/get.py
+++ b/src/provstor/get.py
@@ -76,11 +76,9 @@ def get_file(file_uri, outdir=None):
     return Path(out_path)
 
 
-def get_graph_id(file_id):
+def get_graphs_for_file(file_id):
     qres = run_query(GRAPH_ID_FOR_FILE_QUERY % file_id)
-    assert len(qres) >= 1
-    graph_id = str(list(qres)[0][0])
-    return graph_id
+    return (str(_[0]) for _ in qres)
 
 
 def get_workflow(graph_id):

--- a/src/provstor/get.py
+++ b/src/provstor/get.py
@@ -27,6 +27,7 @@ import zipfile
 from .queries import (
     CRATE_URL_QUERY,
     GRAPH_ID_FOR_FILE_QUERY,
+    GRAPH_ID_FOR_RESULT_QUERY,
     WORKFLOW_QUERY,
     WFRUN_RESULTS_QUERY,
     WFRUN_OBJECTS_QUERY,
@@ -78,6 +79,11 @@ def get_file(file_uri, outdir=None):
 
 def get_graphs_for_file(file_id):
     qres = run_query(GRAPH_ID_FOR_FILE_QUERY % file_id)
+    return (str(_[0]) for _ in qres)
+
+
+def get_graphs_for_result(file_id):
+    qres = run_query(GRAPH_ID_FOR_RESULT_QUERY % file_id)
     return (str(_[0]) for _ in qres)
 
 

--- a/src/provstor/queries.py
+++ b/src/provstor/queries.py
@@ -108,6 +108,21 @@ WHERE {
 }
 """
 
+OBJECTS_FOR_RESULT_QUERY = """\
+PREFIX schema: <http://schema.org/>
+
+SELECT ?object
+WHERE {
+  ?md a schema:CreativeWork .
+  FILTER(contains(str(?md), "ro-crate-metadata.json")) .
+  ?md schema:about ?rde .
+  ?rde schema:mentions ?action .
+  ?action a schema:CreateAction .
+  ?action schema:object ?object .
+  ?action schema:result <%s> .
+}
+"""
+
 WFRUN_PARAMS_QUERY = """\
 PREFIX schema: <http://schema.org/>
 

--- a/src/provstor/queries.py
+++ b/src/provstor/queries.py
@@ -50,6 +50,22 @@ WHERE {
 }
 """
 
+
+GRAPH_ID_FOR_RESULT_QUERY = """\
+PREFIX schema: <http://schema.org/>
+
+SELECT ?url
+WHERE {
+  ?md a schema:CreativeWork .
+  FILTER(contains(str(?md), "ro-crate-metadata.json")) .
+  ?md schema:about ?rde .
+  ?rde schema:url ?url .
+  ?rde schema:mentions ?action .
+  ?action a schema:CreateAction .
+  ?action schema:result <%s> .
+}
+"""
+
 WORKFLOW_QUERY = """\
 PREFIX schema: <http://schema.org/>
 

--- a/src/provstor/queries.py
+++ b/src/provstor/queries.py
@@ -62,7 +62,7 @@ WHERE {
 }
 """
 
-RUN_RESULTS_QUERY = """\
+WFRUN_RESULTS_QUERY = """\
 PREFIX schema: <http://schema.org/>
 
 SELECT ?result
@@ -77,7 +77,7 @@ WHERE {
 }
 """
 
-RUN_OBJECTS_QUERY = """\
+WFRUN_OBJECTS_QUERY = """\
 PREFIX schema: <http://schema.org/>
 
 SELECT ?object
@@ -92,7 +92,7 @@ WHERE {
 }
 """
 
-RUN_PARAMS_QUERY = """\
+WFRUN_PARAMS_QUERY = """\
 PREFIX schema: <http://schema.org/>
 
 SELECT ?name ?value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def data_dir():
 @pytest.fixture(scope="session")
 def crate_map(data_dir):
     m = {}
-    for c in "crate1", "crate2", "provcrate1", "proccrate1":
+    for c in "crate1", "crate2", "provcrate1", "proccrate1", "proccrate2":
         crate_path = data_dir / c
         crate_url = load_crate_metadata(crate_path)
         m[c] = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def data_dir():
 @pytest.fixture(scope="session")
 def crate_map(data_dir):
     m = {}
-    for c in "crate1", "crate2", "provcrate1":
+    for c in "crate1", "crate2", "provcrate1", "proccrate1":
         crate_path = data_dir / c
         crate_url = load_crate_metadata(crate_path)
         m[c] = {

--- a/tests/data/proccrate1/aux.vcf
+++ b/tests/data/proccrate1/aux.vcf
@@ -1,0 +1,1 @@
+## Auxiliary file

--- a/tests/data/proccrate1/ro-crate-metadata.json
+++ b/tests/data/proccrate1/ro-crate-metadata.json
@@ -1,0 +1,96 @@
+{
+    "@context": [
+        "https://w3id.org/ro/crate/1.1/context",
+        "https://w3id.org/ro/terms/workflow-run/context"
+    ],
+    "@graph": [
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "conformsTo": {
+                "@id": "https://w3id.org/ro/crate/1.1"
+            },
+            "about": {
+                "@id": "./"
+            }
+        },
+        {
+            "@id": "./",
+            "@type": "Dataset",
+            "conformsTo": {
+                "@id": "https://w3id.org/ro/wfrun/process/0.5"
+            },
+            "datePublished": "2025-05-26",
+            "hasPart": [
+                {
+                    "@id": "aux.vcf"
+                },
+                {
+                    "@id": "file:///path/to/FOOBAR123.deepvariant.vcf.gz"
+                },
+                {
+                    "@id": "file:///path/to/FOOBAR123.deepvariant.ann.vcf.gz"
+                }
+            ],
+            "mentions": {
+                "@id": "#annotation-1"
+            },
+            "name": "VCF annotation",
+            "description": "hypothetical VCF annotation"
+        },
+        {   "@id": "https://w3id.org/ro/wfrun/process/0.5",
+            "@type": "CreativeWork",
+            "name": "Process Run Crate",
+            "version": "0.5"
+        },
+        {
+            "@id": "https://www.example.com/sw/annotator",
+            "@type": "SoftwareApplication",
+            "url": "https://www.example.com/sw/annotator",
+            "name": "annotator",
+            "softwareVersion": "0.1"
+        },
+        {
+            "@id": "#annotation-1",
+            "@type": "CreateAction",
+            "name": "annotation of FOOBAR123.deepvariant.vcf.gz",
+            "description": "annotation of FOOBAR123.deepvariant.vcf.gz",
+            "endTime": "2025-05-26T15:50:00+02:00",
+            "instrument": {
+                "@id": "https://www.example.com/sw/annotator"
+            },
+            "object": [
+                {
+                    "@id": "aux.vcf"
+                },
+                {
+                    "@id": "file:///path/to/FOOBAR123.deepvariant.vcf.gz"
+                }
+            ],
+            "result": [
+                {
+                    "@id": "file:///path/to/FOOBAR123.deepvariant.ann.vcf.gz"
+                }
+            ]
+        },
+        {
+            "@id": "file:///path/to/FOOBAR123.deepvariant.vcf.gz",
+            "@type": "File",
+            "name": "FOOBAR123.deepvariant.vcf.gz",
+            "sha256": "bf48e57bad6e0fc56e976b4344da8a386319a4bfafc285cb200564451a503158",
+            "contentSize": 31871057156
+        },
+        {
+            "@id": "file:///path/to/FOOBAR123.deepvariant.ann.vcf.gz",
+            "@type": "File",
+            "name": "FOOBAR123.deepvariant.ann.vcf.gz",
+            "sha256": "8ecc09cbcbe3a58c74a6584fde4381ff437c782361d50ea3ee18387c3c709794",
+            "contentSize": 42891067253
+        },
+        {
+            "@id": "aux.vcf",
+            "@type": "File",
+            "name": "aux.vcf"
+        }
+    ]
+}

--- a/tests/data/proccrate2/aux.txt
+++ b/tests/data/proccrate2/aux.txt
@@ -1,0 +1,1 @@
+Auxiliary file

--- a/tests/data/proccrate2/ro-crate-metadata.json
+++ b/tests/data/proccrate2/ro-crate-metadata.json
@@ -1,0 +1,94 @@
+{
+    "@context": [
+        "https://w3id.org/ro/crate/1.1/context",
+        "https://w3id.org/ro/terms/workflow-run/context"
+    ],
+    "@graph": [
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "conformsTo": {
+                "@id": "https://w3id.org/ro/crate/1.1"
+            },
+            "about": {
+                "@id": "./"
+            }
+        },
+        {
+            "@id": "./",
+            "@type": "Dataset",
+            "conformsTo": {
+                "@id": "https://w3id.org/ro/wfrun/process/0.5"
+            },
+            "datePublished": "2025-06-03",
+            "hasPart": [
+                {
+                    "@id": "aux.txt"
+                },
+                {
+                    "@id": "file:///path/to/FOOBAR123.deepvariant.ann.vcf.gz"
+                },
+                {
+                    "@id": "file:///path/to/FOOBAR123.deepvariant.ann.norm.vcf.gz"
+                }
+            ],
+            "mentions": {
+                "@id": "#normalization-1"
+            },
+            "name": "VCF normalization",
+            "description": "hypothetical VCF normalization"
+        },
+        {   "@id": "https://w3id.org/ro/wfrun/process/0.5",
+            "@type": "CreativeWork",
+            "name": "Process Run Crate",
+            "version": "0.5"
+        },
+        {
+            "@id": "https://www.example.com/sw/normalizator",
+            "@type": "SoftwareApplication",
+            "url": "https://www.example.com/sw/normalizator",
+            "name": "normalizator",
+            "softwareVersion": "0.1"
+        },
+        {
+            "@id": "#normalization-1",
+            "@type": "CreateAction",
+            "name": "normalization of FOOBAR123.deepvariant.ann.vcf.gz",
+            "description": "normalization of FOOBAR123.deepvariant.ann.vcf.gz",
+            "endTime": "2025-05-23T09:50:00+02:00",
+            "instrument": {"@id": "https://www.example.com/sw/normalizator"},
+            "object": [
+                {
+                    "@id": "aux.txt"
+                },
+                {
+                    "@id": "file:///path/to/FOOBAR123.deepvariant.ann.vcf.gz"
+                }
+            ],
+            "result": [
+                {
+                    "@id": "file:///path/to/FOOBAR123.deepvariant.ann.norm.vcf.gz"
+                }
+            ]
+        },
+        {
+            "@id": "file:///path/to/FOOBAR123.deepvariant.ann.vcf.gz",
+            "@type": "File",
+            "name": "FOOBAR123.deepvariant.ann.vcf.gz",
+            "sha256": "8ecc09cbcbe3a58c74a6584fde4381ff437c782361d50ea3ee18387c3c709794",
+            "contentSize": 42891067253
+        },
+        {
+            "@id": "file:///path/to/FOOBAR123.deepvariant.ann.norm.vcf.gz",
+            "@type": "File",
+            "name": "FOOBAR123.deepvariant.ann.norm.vcf.gz",
+            "sha256": "86b356751b9947666699ac89977ca5d4666acd61d34cf6cc89aec1ce11712a03",
+            "contentSize": 42895273861
+        },
+        {
+            "@id": "aux.txt",
+            "@type": "File",
+            "name": "aux.txt"
+        }
+    ]
+}

--- a/tests/data/provcrate1/ro-crate-metadata.json
+++ b/tests/data/provcrate1/ro-crate-metadata.json
@@ -68,10 +68,10 @@
                     "@id": "sample.csv"
                 },
                 {
-                    "@id": "file:///path/to/FOOBAR123.md.cram.crai"
+                    "@id": "file:///path/to/FOOBAR123.deepvariant.vcf.gz.tbi"
                 },
                 {
-                    "@id": "file:///path/to/FOOBAR123.md.cram"
+                    "@id": "file:///path/to/FOOBAR123.deepvariant.vcf.gz"
                 }
             ],
             "mainEntity": {
@@ -256,10 +256,10 @@
             ],
             "result": [
                 {
-                    "@id": "file:///path/to/FOOBAR123.md.cram.crai"
+                    "@id": "file:///path/to/FOOBAR123.deepvariant.vcf.gz.tbi"
                 },
                 {
-                    "@id": "file:///path/to/FOOBAR123.md.cram"
+                    "@id": "file:///path/to/FOOBAR123.deepvariant.vcf.gz"
                 }
             ]
         },
@@ -352,42 +352,42 @@
             "encodingFormat": "application/yaml"
         },
         {
-            "@id": "#task/13fc2459df3405bf049e575f063aef3d/FOOBAR123.md.cram.crai",
+            "@id": "#task/13fc2459df3405bf049e575f063aef3d/FOOBAR123.deepvariant.vcf.gz.tbi",
             "@type": "CreativeWork",
-            "name": "FOOBAR123.md.cram.crai"
+            "name": "FOOBAR123.deepvariant.vcf.gz.tbi"
         },
         {
-            "@id": "#task/13fc2459df3405bf049e575f063aef3d/FOOBAR123.md.cram",
+            "@id": "#task/13fc2459df3405bf049e575f063aef3d/FOOBAR123.deepvariant.vcf.gz",
             "@type": "CreativeWork",
-            "name": "FOOBAR123.md.cram"
+            "name": "FOOBAR123.deepvariant.vcf.gz"
         },
         {
-            "@id": "#publish/13fc2459df3405bf049e575f063aef3d/FOOBAR123.md.cram.crai",
+            "@id": "#publish/13fc2459df3405bf049e575f063aef3d/FOOBAR123.deepvariant.vcf.gz.tbi",
             "@type": "CreateAction",
             "name": "publish",
             "instrument": {
                 "@id": "main.nf#software-application"
             },
             "object": {
-                "@id": "#task/13fc2459df3405bf049e575f063aef3d/FOOBAR123.md.cram.crai"
+                "@id": "#task/13fc2459df3405bf049e575f063aef3d/FOOBAR123.deepvariant.vcf.gz.tbi"
             },
             "result": {
-                "@id": "file:///path/to/FOOBAR123.md.cram.crai"
+                "@id": "file:///path/to/FOOBAR123.deepvariant.vcf.gz.tbi"
             },
             "actionStatus": "http://schema.org/CompletedActionStatus"
         },
         {
-            "@id": "#publish/13fc2459df3405bf049e575f063aef3d/FOOBAR123.md.cram",
+            "@id": "#publish/13fc2459df3405bf049e575f063aef3d/FOOBAR123.deepvariant.vcf.gz",
             "@type": "CreateAction",
             "name": "publish",
             "instrument": {
                 "@id": "main.nf#software-application"
             },
             "object": {
-                "@id": "#task/13fc2459df3405bf049e575f063aef3d/FOOBAR123.md.cram"
+                "@id": "#task/13fc2459df3405bf049e575f063aef3d/FOOBAR123.deepvariant.vcf.gz"
             },
             "result": {
-                "@id": "file:///path/to/FOOBAR123.md.cram"
+                "@id": "file:///path/to/FOOBAR123.deepvariant.vcf.gz"
             },
             "actionStatus": "http://schema.org/CompletedActionStatus"
         },
@@ -422,16 +422,16 @@
             "encodingFormat": "text/csv"
         },
         {
-            "@id": "file:///path/to/FOOBAR123.md.cram.crai",
+            "@id": "file:///path/to/FOOBAR123.deepvariant.vcf.gz.tbi",
             "@type": "File",
-            "name": "FOOBAR123.md.cram.crai",
+            "name": "FOOBAR123.deepvariant.vcf.gz.tbi",
             "sha256": "38fdf473549d817821bfc8e78242b592ac2d9f02fd2213cf955c5e409135fc7e",
             "contentSize": 3950691
         },
         {
-            "@id": "file:///path/to/FOOBAR123.md.cram",
+            "@id": "file:///path/to/FOOBAR123.deepvariant.vcf.gz",
             "@type": "File",
-            "name": "FOOBAR123.md.cram",
+            "name": "FOOBAR123.deepvariant.vcf.gz",
             "sha256": "bf48e57bad6e0fc56e976b4344da8a386319a4bfafc285cb200564451a503158",
             "contentSize": 31871057156
         }

--- a/tests/test_backtrack.py
+++ b/tests/test_backtrack.py
@@ -1,0 +1,43 @@
+# Copyright © 2024-2025 CRS4
+#
+# This file is part of ProvStor.
+#
+# ProvStor is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# ProvStor is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ProvStor. If not, see <https://www.gnu.org/licenses/>.
+
+from provstor.backtrack import backtrack
+
+
+def test_backtrack(crate_map):
+    proccrate2_rde_id = crate_map["proccrate2"]["rde_id"]
+    proccrate1_rde_id = crate_map["proccrate1"]["rde_id"]
+    provcrate1_rde_id = crate_map["provcrate1"]["rde_id"]
+    result_id = "file:///path/to/FOOBAR123.deepvariant.ann.norm.vcf.gz"
+    items = [set(_) for _ in backtrack(result_id)]
+    assert len(items) >= 3
+    assert items[0] >= {
+        f"{proccrate2_rde_id}aux.txt",
+        "file:///path/to/FOOBAR123.deepvariant.ann.vcf.gz"
+    }
+    assert items[1] >= {
+        f"{proccrate1_rde_id}aux.vcf",
+        "file:///path/to/FOOBAR123.deepvariant.vcf.gz"
+    }
+    assert items[2] >= {
+        f"{provcrate1_rde_id}#param/input/value",
+        f"{provcrate1_rde_id}#param/foo/value",
+        "file:///path/to/FOOBAR123_1.fastq.gz",
+        "file:///path/to/FOOBAR123_2.fastq.gz",
+        "file:///path/to/pipeline_info/software_versions.yml",
+        "http://example.com/fooconfig.yml",
+        f"{provcrate1_rde_id}sample.csv",
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,7 +85,7 @@ def test_cli_get_file(crate_map, tmp_path, monkeypatch, cwd):
 
 def test_cli_get_graph_id(crate_map):
     runner = CliRunner()
-    args = ["get-graph-id", "file:///path/to/FOOBAR123.md.cram"]
+    args = ["get-graph-id", "file:///path/to/FOOBAR123.deepvariant.vcf.gz"]
     result = runner.invoke(cli, args)
     assert result.exit_code == 0, result.exception
     assert result.stdout.rstrip() == crate_map["provcrate1"]["url"]
@@ -108,8 +108,8 @@ def test_cli_get_run_results(crate_map):
     result = runner.invoke(cli, args)
     assert result.exit_code == 0, result.exception
     assert set(result.stdout.splitlines()) == {
-        "file:///path/to/FOOBAR123.md.cram.crai",
-        "file:///path/to/FOOBAR123.md.cram"
+        "file:///path/to/FOOBAR123.deepvariant.vcf.gz.tbi",
+        "file:///path/to/FOOBAR123.deepvariant.vcf.gz"
     }
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -111,7 +111,7 @@ def test_cli_get_workflow(crate_map):
     args = ["get-workflow", crate_url]
     result = runner.invoke(cli, args)
     assert result.exit_code == 0, result.exception
-    assert result.stdout.rstrip() == rde_id + "main.nf"
+    assert set(result.stdout.splitlines()) == {rde_id + "main.nf"}
 
 
 def test_cli_get_run_results(crate_map):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,12 +83,15 @@ def test_cli_get_file(crate_map, tmp_path, monkeypatch, cwd):
     assert (tmp_path / "ro-crate-metadata.json").is_file()
 
 
-def test_cli_get_graph_id(crate_map):
+def test_cli_get_graphs_for_file(crate_map):
     runner = CliRunner()
-    args = ["get-graph-id", "file:///path/to/FOOBAR123.deepvariant.vcf.gz"]
+    args = ["get-graphs-for-file", "file:///path/to/FOOBAR123.deepvariant.vcf.gz"]
     result = runner.invoke(cli, args)
     assert result.exit_code == 0, result.exception
-    assert result.stdout.rstrip() == crate_map["provcrate1"]["url"]
+    assert set(result.stdout.splitlines()) >= {
+        f"http://{MINIO_STORE}/{MINIO_BUCKET}/proccrate1.zip",
+        f"http://{MINIO_STORE}/{MINIO_BUCKET}/provcrate1.zip"
+    }
 
 
 def test_cli_get_workflow(crate_map):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -94,6 +94,16 @@ def test_cli_get_graphs_for_file(crate_map):
     }
 
 
+def test_cli_get_graphs_for_result(crate_map):
+    runner = CliRunner()
+    args = ["get-graphs-for-result", "file:///path/to/FOOBAR123.deepvariant.vcf.gz"]
+    result = runner.invoke(cli, args)
+    assert result.exit_code == 0, result.exception
+    assert set(result.stdout.splitlines()) >= {
+        f"http://{MINIO_STORE}/{MINIO_BUCKET}/provcrate1.zip"
+    }
+
+
 def test_cli_get_workflow(crate_map):
     runner = CliRunner()
     crate_url = crate_map["provcrate1"]["url"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -142,6 +142,37 @@ def test_cli_get_run_objects(crate_map):
     }
 
 
+def test_cli_get_objects_for_result(crate_map):
+    runner = CliRunner()
+    proccrate1_rde_id = crate_map["proccrate1"]["rde_id"]
+    result_id = "file:///path/to/FOOBAR123.deepvariant.ann.vcf.gz"
+    args = ["get-objects-for-result", result_id]
+    result = runner.invoke(cli, args)
+    assert result.exit_code == 0, result.exception
+    assert set(result.stdout.splitlines()) == {
+        f"{proccrate1_rde_id}aux.vcf",
+        "file:///path/to/FOOBAR123.deepvariant.vcf.gz"
+    }
+    args = ["get-objects-for-result", f"{proccrate1_rde_id}aux.vcf"]
+    result = runner.invoke(cli, args)
+    assert result.exit_code == 0, result.exception
+    assert len(result.stdout.splitlines()) == 0
+    provcrate1_rde_id = crate_map["provcrate1"]["rde_id"]
+    args = ["get-objects-for-result", "file:///path/to/FOOBAR123.deepvariant.vcf.gz"]
+    result = runner.invoke(cli, args)
+    assert result.exit_code == 0, result.exception
+    assert set(result.stdout.splitlines()) == {
+        f"{provcrate1_rde_id}#param/input/value",
+        f"{provcrate1_rde_id}#param/foo/value",
+        "file:///path/to/FOOBAR123_1.fastq.gz",
+        "file:///path/to/FOOBAR123_2.fastq.gz",
+        "file:///path/to/pipeline_info/software_versions.yml",
+        "http://example.com/fooconfig.yml",
+        f"{provcrate1_rde_id}sample.csv",
+    }
+
+
+
 def test_cli_get_run_params(crate_map):
     runner = CliRunner()
     crate_url = crate_map["provcrate1"]["url"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -172,7 +172,6 @@ def test_cli_get_objects_for_result(crate_map):
     }
 
 
-
 def test_cli_get_run_params(crate_map):
     runner = CliRunner()
     crate_url = crate_map["provcrate1"]["url"]
@@ -194,4 +193,35 @@ def test_cli_list_graphs(crate_map):
         f"http://{MINIO_STORE}/{MINIO_BUCKET}/crate1.zip",
         f"http://{MINIO_STORE}/{MINIO_BUCKET}/crate2.zip",
         f"http://{MINIO_STORE}/{MINIO_BUCKET}/provcrate1.zip",
+    }
+
+
+def test_cli_backtrack(crate_map):
+    def to_set(ln):
+        return set([_.strip("'") for _ in ln.strip("[]").split("', '")])
+    runner = CliRunner()
+    proccrate2_rde_id = crate_map["proccrate2"]["rde_id"]
+    proccrate1_rde_id = crate_map["proccrate1"]["rde_id"]
+    provcrate1_rde_id = crate_map["provcrate1"]["rde_id"]
+    result_id = "file:///path/to/FOOBAR123.deepvariant.ann.norm.vcf.gz"
+    args = ["backtrack", result_id]
+    result = runner.invoke(cli, args)
+    assert result.exit_code == 0, result.exception
+    items = [to_set(_) for _ in result.stdout.splitlines()]
+    assert items[0] >= {
+        f"{proccrate2_rde_id}aux.txt",
+        "file:///path/to/FOOBAR123.deepvariant.ann.vcf.gz"
+    }
+    assert items[1] >= {
+        f"{proccrate1_rde_id}aux.vcf",
+        "file:///path/to/FOOBAR123.deepvariant.vcf.gz"
+    }
+    assert items[2] >= {
+        f"{provcrate1_rde_id}#param/input/value",
+        f"{provcrate1_rde_id}#param/foo/value",
+        "file:///path/to/FOOBAR123_1.fastq.gz",
+        "file:///path/to/FOOBAR123_2.fastq.gz",
+        "file:///path/to/pipeline_info/software_versions.yml",
+        "http://example.com/fooconfig.yml",
+        f"{provcrate1_rde_id}sample.csv",
     }

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -60,7 +60,7 @@ def test_get_file(crate_map, tmp_path, monkeypatch, cwd):
 
 
 def test_get_graph_id(crate_map):
-    graph_id = get_graph_id("file:///path/to/FOOBAR123.md.cram")
+    graph_id = get_graph_id("file:///path/to/FOOBAR123.deepvariant.vcf.gz")
     assert graph_id == f"http://{MINIO_STORE}/{MINIO_BUCKET}/provcrate1.zip"
 
 
@@ -75,8 +75,8 @@ def test_get_run_results(crate_map):
     graph_id = crate_map["provcrate1"]["url"]
     results = set(get_run_results(graph_id))
     assert results == {
-        "file:///path/to/FOOBAR123.md.cram.crai",
-        "file:///path/to/FOOBAR123.md.cram"
+        "file:///path/to/FOOBAR123.deepvariant.vcf.gz.tbi",
+        "file:///path/to/FOOBAR123.deepvariant.vcf.gz"
     }
 
 

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -28,6 +28,7 @@ from provstor.get import (
     get_workflow,
     get_run_results,
     get_run_objects,
+    get_objects_for_result,
     get_run_params
 )
 
@@ -101,6 +102,29 @@ def test_get_run_objects(crate_map):
         "file:///path/to/pipeline_info/software_versions.yml",
         "http://example.com/fooconfig.yml",
         f"{rde_id}sample.csv"
+    }
+
+
+def test_get_objects_for_result(crate_map):
+    proccrate1_rde_id = crate_map["proccrate1"]["rde_id"]
+    result_id = "file:///path/to/FOOBAR123.deepvariant.ann.vcf.gz"
+    objects = set(get_objects_for_result(result_id))
+    assert objects >= {
+        f"{proccrate1_rde_id}aux.vcf",
+        "file:///path/to/FOOBAR123.deepvariant.vcf.gz"
+    }
+    objects = set(get_objects_for_result(f"{proccrate1_rde_id}aux.vcf"))
+    assert len(objects) == 0
+    provcrate1_rde_id = crate_map["provcrate1"]["rde_id"]
+    objects = set(get_objects_for_result("file:///path/to/FOOBAR123.deepvariant.vcf.gz"))
+    assert objects >= {
+        f"{provcrate1_rde_id}#param/input/value",
+        f"{provcrate1_rde_id}#param/foo/value",
+        "file:///path/to/FOOBAR123_1.fastq.gz",
+        "file:///path/to/FOOBAR123_2.fastq.gz",
+        "file:///path/to/pipeline_info/software_versions.yml",
+        "http://example.com/fooconfig.yml",
+        f"{provcrate1_rde_id}sample.csv",
     }
 
 

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -24,6 +24,7 @@ from provstor.get import (
     get_crate,
     get_file,
     get_graphs_for_file,
+    get_graphs_for_result,
     get_workflow,
     get_run_results,
     get_run_objects,
@@ -63,6 +64,13 @@ def test_get_graphs_for_file(crate_map):
     graphs = get_graphs_for_file("file:///path/to/FOOBAR123.deepvariant.vcf.gz")
     assert set(graphs) >= {
         f"http://{MINIO_STORE}/{MINIO_BUCKET}/proccrate1.zip",
+        f"http://{MINIO_STORE}/{MINIO_BUCKET}/provcrate1.zip"
+    }
+
+
+def test_get_graphs_for_result(crate_map):
+    graphs = get_graphs_for_result("file:///path/to/FOOBAR123.deepvariant.vcf.gz")
+    assert set(graphs) >= {
         f"http://{MINIO_STORE}/{MINIO_BUCKET}/provcrate1.zip"
     }
 

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -78,8 +78,8 @@ def test_get_graphs_for_result(crate_map):
 def test_get_workflow(crate_map):
     graph_id = crate_map["provcrate1"]["url"]
     rde_id = crate_map["provcrate1"]["rde_id"]
-    workflow = get_workflow(graph_id)
-    assert workflow == f"{rde_id}main.nf"
+    results = set(get_workflow(graph_id))
+    assert results == {f"{rde_id}main.nf"}
 
 
 def test_get_run_results(crate_map):

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -23,7 +23,7 @@ from provstor.config import MINIO_STORE, MINIO_BUCKET
 from provstor.get import (
     get_crate,
     get_file,
-    get_graph_id,
+    get_graphs_for_file,
     get_workflow,
     get_run_results,
     get_run_objects,
@@ -59,9 +59,12 @@ def test_get_file(crate_map, tmp_path, monkeypatch, cwd):
     assert filecmp.cmp(out_md_path, md_path)
 
 
-def test_get_graph_id(crate_map):
-    graph_id = get_graph_id("file:///path/to/FOOBAR123.deepvariant.vcf.gz")
-    assert graph_id == f"http://{MINIO_STORE}/{MINIO_BUCKET}/provcrate1.zip"
+def test_get_graphs_for_file(crate_map):
+    graphs = get_graphs_for_file("file:///path/to/FOOBAR123.deepvariant.vcf.gz")
+    assert set(graphs) >= {
+        f"http://{MINIO_STORE}/{MINIO_BUCKET}/proccrate1.zip",
+        f"http://{MINIO_STORE}/{MINIO_BUCKET}/provcrate1.zip"
+    }
 
 
 def test_get_workflow(crate_map):


### PR DESCRIPTION
* Queries that are meant to operate on Workflow Run (or Provenance) Crates have been renamed with a leading `WFRUN`.
* `get_graph_id` has been renamed to `get_graphs_for_file`, since the query can return more than one item. For instance, a `file:///foo/bar.txt` can appear in more than one crate, possibly with different roles (e.g. as an `object` and as a `result`)
* Added a new `get_graphs_for_result(result_id)` function that gets only the graphs where `result_id` appears as the `result` of a `CreateAction`.
* Added a new `get_objects_for_result(result_id)` function that gets the `object`s of a `CreateAction` where `result_id` appears as a `result`.
* Added a new `backtrack(result_id)` function that recursively calls `get_objects_for_result` on chains of actions. This is meant to operate on scenarios where a crate uses the results of another crate as objects for a new `CreateAction`, whose results are (possibly) in turn used as objects for yet another `CreateAction`, and so on.
* Changed `get_workflow` to return an empty result (instead of crashing) when there is no main workfow in the crate.
