### PR TITLE
Select only files and dirs in OBJECTS_FOR_RESULT_QUERY

### DIFF
--- a/src/provstor/queries.py
+++ b/src/provstor/queries.py
@@ -120,6 +120,7 @@ WHERE {
   ?action a schema:CreateAction .
   ?action schema:object ?object .
   ?action schema:result <%s> .
+  { ?object a schema:MediaObject } UNION { ?object a schema:Dataset }
 }
 """
 

--- a/tests/test_backtrack.py
+++ b/tests/test_backtrack.py
@@ -33,8 +33,6 @@ def test_backtrack(crate_map):
         "file:///path/to/FOOBAR123.deepvariant.vcf.gz"
     }
     assert items[2] >= {
-        f"{provcrate1_rde_id}#param/input/value",
-        f"{provcrate1_rde_id}#param/foo/value",
         "file:///path/to/FOOBAR123_1.fastq.gz",
         "file:///path/to/FOOBAR123_2.fastq.gz",
         "file:///path/to/pipeline_info/software_versions.yml",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,8 +162,6 @@ def test_cli_get_objects_for_result(crate_map):
     result = runner.invoke(cli, args)
     assert result.exit_code == 0, result.exception
     assert set(result.stdout.splitlines()) == {
-        f"{provcrate1_rde_id}#param/input/value",
-        f"{provcrate1_rde_id}#param/foo/value",
         "file:///path/to/FOOBAR123_1.fastq.gz",
         "file:///path/to/FOOBAR123_2.fastq.gz",
         "file:///path/to/pipeline_info/software_versions.yml",
@@ -217,8 +215,6 @@ def test_cli_backtrack(crate_map):
         "file:///path/to/FOOBAR123.deepvariant.vcf.gz"
     }
     assert items[2] >= {
-        f"{provcrate1_rde_id}#param/input/value",
-        f"{provcrate1_rde_id}#param/foo/value",
         "file:///path/to/FOOBAR123_1.fastq.gz",
         "file:///path/to/FOOBAR123_2.fastq.gz",
         "file:///path/to/pipeline_info/software_versions.yml",

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -118,8 +118,6 @@ def test_get_objects_for_result(crate_map):
     provcrate1_rde_id = crate_map["provcrate1"]["rde_id"]
     objects = set(get_objects_for_result("file:///path/to/FOOBAR123.deepvariant.vcf.gz"))
     assert objects >= {
-        f"{provcrate1_rde_id}#param/input/value",
-        f"{provcrate1_rde_id}#param/foo/value",
         "file:///path/to/FOOBAR123_1.fastq.gz",
         "file:///path/to/FOOBAR123_2.fastq.gz",
         "file:///path/to/pipeline_info/software_versions.yml",


### PR DESCRIPTION
This is consistent with `WFRUN_OBJECTS_QUERY`. Also, oddly, when doing a backtrack involving a real Sarek nf-prov output crate, the previous version leads to an infinite recursion.