### PR TITLE
Fix error handling in backtrack

### DIFF
--- a/src/provstor_api/routes/backtrack.py
+++ b/src/provstor_api/routes/backtrack.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with ProvStor. If not, see <https://www.gnu.org/licenses/>.
 
-
 from fastapi import APIRouter, HTTPException
 from utils.get_utils import (
     fetch_actions_for_result, fetch_objects_for_action, fetch_results_for_action
@@ -36,55 +35,45 @@ def _backtrack_recursive(result_id, visited=None):
     visited.add(result_id)
     results = []
 
-    try:
-        actions = fetch_actions_for_result(result_id)
-        for a in actions:
-            objects = fetch_objects_for_action(a)
-            action_results = fetch_results_for_action(a)
-            results.append({
-                "action": a,
-                "objects": objects,
-                "results": action_results
-            })
+    actions = fetch_actions_for_result(result_id)
+    for a in actions:
+        objects = fetch_objects_for_action(a)
+        action_results = fetch_results_for_action(a)
+        results.append({
+            "action": a,
+            "objects": objects,
+            "results": action_results
+        })
 
-            for obj in objects:
-                nested_results = _backtrack_recursive(obj, visited)
-                results.extend(nested_results)
-
-    except Exception:
-        pass  # Handle gracefully if no actions found
+        for obj in objects:
+            nested_results = _backtrack_recursive(obj, visited)
+            results.extend(nested_results)
 
     return results
 
 
 @router.get("/")
 def backtrack_fn(file_uri: str = None, result_id: str = None):
-    try:
-        target_result_id = result_id
+    target_result_id = result_id
 
-        if file_uri and not result_id:
-            graphs = run_query(GRAPH_ID_FOR_FILE_QUERY % file_uri)
-            if not graphs:
-                raise HTTPException(status_code=404, detail="No graphs found for the given file")
+    if file_uri and not result_id:
+        graphs = run_query(GRAPH_ID_FOR_FILE_QUERY % file_uri)
+        if not graphs:
+            raise HTTPException(status_code=404, detail="No graphs found for the given file")
 
-            graph_id = str(list(graphs)[0][0])
-            results = run_query(WFRUN_RESULTS_QUERY, graph_id=graph_id)
-            if not results:
-                raise HTTPException(status_code=404, detail="No results found for the file")
+        graph_id = str(list(graphs)[0][0])
+        results = run_query(WFRUN_RESULTS_QUERY, graph_id=graph_id)
+        if not results:
+            raise HTTPException(status_code=404, detail="No results found for the file")
 
-            target_result_id = str(list(results)[0][0])
+        target_result_id = str(list(results)[0][0])
 
-        if not target_result_id:
-            raise HTTPException(status_code=400, detail="Either file_uri or result_id must be provided")
+    if not target_result_id:
+        raise HTTPException(status_code=400, detail="Either file_uri or result_id must be provided")
 
-        backtrack_results = _backtrack_recursive(target_result_id)
+    backtrack_results = _backtrack_recursive(target_result_id)
 
-        if not backtrack_results:
-            raise HTTPException(status_code=404, detail="No backtrack results found")
+    if not backtrack_results:
+        raise HTTPException(status_code=404, detail="No backtrack results found")
 
-        return {"result": backtrack_results}
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    return {"result": backtrack_results}


### PR DESCRIPTION
In backtrack, if [`results = []`](https://github.com/crs4/provenance-storage/blob/3edb8dc4da403600ddd8bf1dcaa834563e4b34ac/src/provstor_api/routes/backtrack.py#L37) is replaced with `results = None`, the subsequent [`results.append`](https://github.com/crs4/provenance-storage/blob/3edb8dc4da403600ddd8bf1dcaa834563e4b34ac/src/provstor_api/routes/backtrack.py#L44) should fail with an `AttributeError` and the client should get a 500 (and the server should show the stack trace for debugging), but the error is swallowed by the `try ... except` block and the client gets a 404 Not Found. If the above `try ... except` block is removed, the client gets a 500, but the stack trace is sill not shown: this is due to the fact that there's another external `try ... except` block in the caller, `bactrack_fn`. If this second block is removed, the client still gets a 500 (automatically handled by FastAPI / Starlette) and the stack trace is finally shown in the server log:

```
...
provstor-api  |   File "/app/provstor_api/routes/backtrack.py", line 42, in _backtrack_recursive
provstor-api  |     results.append({
provstor-api  |     ^^^^^^^^^^^^^^
provstor-api  | AttributeError: 'NoneType' object has no attribute 'append'
```

This PR removes both `try ... except` blocks to fix the response type and make the code debuggable.