### PR TITLE
provstor-api image: run as non-root user

### DIFF
--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -5,9 +5,13 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY src/provstor_api ./provstor_api
+RUN groupadd -g 1000 provstor && \
+    useradd -u 1000 -g provstor provstor
+
+COPY --chown=provstor:provstor src/provstor_api ./provstor_api
 
 ENV PYTHONPATH=/app
+ENV USER=provstor
 
 EXPOSE 8000
 CMD ["python3", "provstor_api/main.py"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,7 +48,8 @@ services:
     restart: "no"
 
   api:
-    image: provstor-api:1.0
+    image: provstor-api:1.1
+    user: "1000"
     build:
       context: .
       dockerfile: api.Dockerfile


### PR DESCRIPTION
In dev mode, the provstor-api image running as root generates `__pycache__` directories in the source code with files owned by root, so that e.g. `git clean` fails. This PR sets the API image to run as a non-privileged `provstor` user.