### PR TITLE
Switch to SeaweedFS as the object store

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,13 +5,15 @@ FUSEKI_DATASET=ds
 # Fuseki Authentication
 FUSEKI_ADMIN_PASSWORD=admin
 
-# MinIO Configuration
-MINIO_STORE=minio:9000
-MINIO_BUCKET=crates
+# SeaweedFS configuration
+SEAWEEDFS_STORE=seaweedfs-s3:8333
+SEAWEEDFS_FILER=seaweedfs-s3:8888
+SEAWEEDFS_BUCKET=crates
 
-# MinIO authentication
-MINIO_USER=minioadmin
-MINIO_SECRET=minioadmin
+# SeaweedFS authentication
+SEAWEEDFS_USER=admin
+SEAWEEDFS_ACCESS_KEY=admin_access_key
+SEAWEEDFS_SECRET_KEY=admin_secret_key
 
 # Docker-specific settings
 QUERY_TIMEOUT=60000

--- a/README.md
+++ b/README.md
@@ -14,22 +14,10 @@ docker compose up
 ```
 
 * Open http://localhost:3030 in a browser window to access the Fuseki web UI. The username is `admin` and the password is `admin`.
-* Open http://localhost:9001 to access the MinIO web UI. The username is `minioadmin` and the password `minioadmin`.
+* Open http://localhost:8888 to access the SeaweedFS Filer web UI.
 * Open http://localhost:8000/docs to access the FastAPI Swagger UI.
 
 To change passwords and other configuration values, edit the `.env` file before running `docker compose up`.
-
-Switch to another terminal window.
-
-Install the MinIO client command line tool `mc` following the [MinIO Quickstart](https://min.io/docs/minio/linux/reference/minio-mc.html#quickstart).
-
-Create an alias:
-
-```
-mc alias set localstore http://localhost:9000 minio miniosecret
-```
-
-The above modifies `~/.mc/config.json`, so it does not need to be re-executed if you wipe out `minio-data`.
 
 
 ### Environment Configuration

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,19 +33,44 @@ services:
       - fuseki-data:/fuseki-base/databases
     restart: "no"
 
-  minio:
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
-    container_name: minio
-    command: server /data --console-address ":9001"
+  seaweedfs-s3:
+    image: chrislusf/seaweedfs:4.17
+    container_name: seaweedfs-s3
     ports:
-      - 9000:9000
-      - 9001:9001
-    environment:
-      - MINIO_ROOT_USER=${MINIO_USER}
-      - MINIO_ROOT_PASSWORD=${MINIO_SECRET}
+      - "8333:8333"
+      - "8888:8888"
+    entrypoint: /bin/sh -c
+    command: |
+      "echo '{
+        \"identities\": [
+          {
+            \"name\": \"anonymous\",
+            \"actions\": [
+              \"Read\"
+            ]
+          },
+          {
+            \"name\": \"${SEAWEEDFS_USER}\",
+            \"credentials\": [
+              {
+                \"accessKey\": \"${SEAWEEDFS_ACCESS_KEY}\",
+                \"secretKey\": \"${SEAWEEDFS_SECRET_KEY}\"
+              }
+            ],
+            \"actions\": [
+              \"Admin\",
+              \"Read\",
+              \"List\",
+              \"Tagging\",
+              \"Write\"
+            ]
+          }
+        ]
+      }' > /etc/seaweedfs/config.json && \
+      weed server -dir /s3data -s3 -s3.config /etc/seaweedfs/config.json -filer"
     volumes:
-      - minio-data:/data
-    restart: "no"
+      - seaweedfs-data:/s3data
+    restart: no
 
   api:
     image: provstor-api:1.1
@@ -59,17 +84,19 @@ services:
     environment:
       - FUSEKI_BASE_URL=${FUSEKI_BASE_URL}
       - FUSEKI_DATASET=${FUSEKI_DATASET}
-      - MINIO_STORE=${MINIO_STORE}
-      - MINIO_USER=${MINIO_USER}
-      - MINIO_SECRET=${MINIO_SECRET}
-      - MINIO_BUCKET=${MINIO_BUCKET}
+      - SEAWEEDFS_STORE=${SEAWEEDFS_STORE}
+      - SEAWEEDFS_FILER=${SEAWEEDFS_FILER}
+      - SEAWEEDFS_USER=${SEAWEEDFS_USER}
+      - SEAWEEDFS_ACCESS_KEY=${SEAWEEDFS_ACCESS_KEY}
+      - SEAWEEDFS_SECRET_KEY=${SEAWEEDFS_SECRET_KEY}
+      - SEAWEEDFS_BUCKET=${SEAWEEDFS_BUCKET}
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS}
     depends_on:
       - fuseki
-      - minio
+      - seaweedfs-s3
     restart: "no"
     pull_policy: never
 
 volumes:
   fuseki-data:
-  minio-data:
+  seaweedfs-data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [{name = "CRS4", email = "ro-crate@elixir-europe.org"}, {name = "RO-Cr
 requires-python = ">=3.12, <4"
 dependencies = [
     "rdflib~=7.0.0",
-    "minio~=7.2.0",
+    "boto3~=1.42.71",
     "arcp==0.2.1",
     "click~=8.1",
     "fastapi~=0.116.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ pydantic-settings~=2.10.1
 pycparser~=2.22
 python-multipart~=0.0.20
 arcp~=0.2.1
-minio~=7.2.16
+boto3~=1.42.71
 httpx~=0.28.0
 rocrate~=0.14.0

--- a/src/provstor/cli.py
+++ b/src/provstor/cli.py
@@ -69,7 +69,7 @@ def cli(log_level):
 )
 def load(crate):
     """\
-    Load RO-Crate metadata into Fuseki and upload zipped crate to MinIO.
+    Load RO-Crate metadata into Fuseki and upload zipped crate to SeaweedFS.
 
     RO_CRATE: RO-Crate directory or ZIP archive.
     """

--- a/src/provstor_api/config.py
+++ b/src/provstor_api/config.py
@@ -20,10 +20,12 @@ from pydantic_settings import BaseSettings
 
 # Pydantic reads the environment variables in a case-insensitive way
 class Settings(BaseSettings):
-    minio_store: str = "minio:9000"
-    minio_user: str = "minioadmin"
-    minio_secret: str = "minioadmin"
-    minio_bucket: str = "crates"
+    seaweedfs_store: str = "seaweedfs-s3:8333"
+    seaweedfs_filer: str = "seaweedfs-s3:8888"
+    seaweedfs_bucket: str = "crates"
+    seaweedfs_user: str = "admin"
+    seaweedfs_access_key: str = "admin_access_key"
+    seaweedfs_secret_key: str = "admin_secret_key"
     fuseki_base_url: str = "http://fuseki:3030"
     fuseki_dataset: str = "ds"
     cors_allowed_origins: str = ""

--- a/src/provstor_api/routes/upload.py
+++ b/src/provstor_api/routes/upload.py
@@ -17,13 +17,12 @@
 
 
 from fastapi import APIRouter, UploadFile, HTTPException
-import json
 import logging
 import tempfile
 import zipfile
 import os
 import arcp
-from minio import Minio
+import boto3
 from rdflib import Graph
 from rdflib.plugins.stores.sparqlstore import SPARQLUpdateStore
 from rdflib.term import URIRef, Literal
@@ -34,24 +33,6 @@ from provstor_api.config import settings
 
 router = APIRouter()
 
-# anonymous read-only policy, see https://github.com/minio/minio-py/blob/88f4244fe89fb9f23de4f183bdf79524c712deaa/examples/set_bucket_policy.py#L27
-MINIO_BUCKET_POLICY = {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Principal": {"AWS": "*"},
-            "Action": ["s3:GetBucketLocation", "s3:ListBucket"],
-            "Resource": f"arn:aws:s3:::{settings.minio_bucket}",
-        },
-        {
-            "Effect": "Allow",
-            "Principal": {"AWS": "*"},
-            "Action": "s3:GetObject",
-            "Resource": f"arn:aws:s3:::{settings.minio_bucket}/*",
-        },
-    ],
-}
 
 EXTERNAL_RESULTS_QUERY = """\
 PREFIX schema: <http://schema.org/>
@@ -76,7 +57,7 @@ async def load_crate_metadata(crate_path: UploadFile):
     if not content:
         raise HTTPException(status_code=400, detail="Empty file uploaded.")
 
-    crate_url = f"http://{settings.minio_store}/{settings.minio_bucket}/{crate_path.filename}"
+    crate_url = f"http://{settings.seaweedfs_filer}/buckets/{settings.seaweedfs_bucket}/{crate_path.filename}"
     logging.info("Crate URL: %s", crate_url)
     loc = arcp.arcp_location(crate_url)
     logging.info("ARCP location: %s", loc)
@@ -126,27 +107,24 @@ async def load_crate_metadata(crate_path: UploadFile):
         if isinstance(metadata, bytes):
             metadata = metadata.decode()
 
-        client = Minio(
-            endpoint=settings.minio_store,
-            access_key=settings.minio_user,
-            secret_key=settings.minio_secret,
-            secure=False
+        client = boto3.client(
+            "s3",
+            endpoint_url=f"http://{settings.seaweedfs_store}",
+            aws_access_key_id=settings.seaweedfs_access_key,
+            aws_secret_access_key=settings.seaweedfs_secret_key,
         )
-        if not client.bucket_exists(bucket_name=settings.minio_bucket):
-            client.make_bucket(bucket_name=settings.minio_bucket)
-            logging.info('created bucket "%s"', settings.minio_bucket)
-            client.set_bucket_policy(
-                bucket_name=settings.minio_bucket,
-                policy=json.dumps(MINIO_BUCKET_POLICY)
-            )
+        try:
+            client.create_bucket(Bucket=settings.seaweedfs_bucket)
+        except client.exceptions.BucketAlreadyExists:
+            pass
+        else:
+            logging.info('created bucket "%s"', settings.seaweedfs_bucket)
 
         await crate_path.seek(0)
         client.put_object(
-            bucket_name=settings.minio_bucket,
-            object_name=crate_path.filename,
-            data=crate_path.file,
-            length=-1,
-            part_size=50 * 1024 * 1024
+            Bucket=settings.seaweedfs_bucket,
+            Key=crate_path.filename,
+            Body=crate_path.file,
         )
 
         try:
@@ -157,9 +135,9 @@ async def load_crate_metadata(crate_path: UploadFile):
             graph = Graph(store, identifier=URIRef(crate_url))
             graph.update(INSERT_QUERY % metadata)
         except Exception as e:
-            client.remove_object(
-                bucket_name=settings.minio_bucket,
-                object_name=crate_path.filename
+            client.delete_object(
+                Bucket=settings.seaweedfs_bucket,
+                Key=crate_path.filename,
             )
             raise HTTPException(status_code=500, detail=f"Failed to upload metadata to the store: {e}")
         return {"result": "success", "crate_url": crate_url}

--- a/src/provstor_api/utils/query.py
+++ b/src/provstor_api/utils/query.py
@@ -28,7 +28,7 @@ def run_query(query, graph_id=None):
     store.open(query_endpoint)
     if graph_id:
         if not graph_id.startswith("http://"):
-            graph_id = f"http://{settings.minio_store}/{settings.minio_bucket}/{graph_id}.zip"
+            graph_id = f"http://{settings.seaweedfs_filer}/buckets/{settings.seaweedfs_bucket}/{graph_id}.zip"
         graph_id = URIRef(graph_id)
     qres = store.query(query, queryGraph=graph_id)
     return qres

--- a/tests/test_api_unit.py
+++ b/tests/test_api_unit.py
@@ -34,9 +34,9 @@ import provstor_api.routes.pathops as pathops
 # Test Constants
 class TestConstants:
     # URLs and URIs
-    MINIO_URL = "http://minio:9000"
-    MINIO_STORE = "minio:9000"
-    MINIO_BUCKET = "crates"
+    SEAWEEDFS_FILER = "seaweedfs-s3:8888"
+    SEAWEEDFS_STORE = "seaweedfs-s3:8333"
+    SEAWEEDFS_BUCKET = "crates"
     FUSEKI_URL = "http://fuseki:3030"
     FUSEKI_DATASET = "ds"
 
@@ -133,17 +133,11 @@ def make_zip_bytes(files: dict[str, bytes]) -> bytes:
 
 @pytest.fixture
 def mock_client(monkeypatch):
-    class MockMinio:
-        def __init__(self, **kw):
+    class MockClient:
+        def __init__(self, *args, **kw):
             pass
 
-        def bucket_exists(self, **kw):
-            return True
-
-        def make_bucket(self, **kw):
-            pass
-
-        def set_bucket_policy(self, **kw):
+        def create_bucket(self, **kw):
             pass
 
         def put_object(self, **kw):
@@ -173,14 +167,14 @@ def mock_client(monkeypatch):
         def update(self, insert_query):
             self.insert_query = insert_query
 
-    monkeypatch.setattr(upload, "Minio", MockMinio)
+    monkeypatch.setattr(upload.boto3, "client", MockClient)
     monkeypatch.setattr(upload, "SPARQLUpdateStore", MockStore)
     monkeypatch.setattr(upload, "Graph", MockGraph)
     monkeypatch.setattr(upload, "run_query", lambda q: [])
     monkeypatch.setattr(upload.arcp, "arcp_location", lambda url: TC.ARCP_LOCATION)
 
-    upload.settings.minio_store = TC.MINIO_STORE
-    upload.settings.minio_bucket = TC.MINIO_BUCKET
+    upload.settings.seaweedfs_store = TC.SEAWEEDFS_STORE
+    upload.settings.seaweedfs_bucket = TC.SEAWEEDFS_BUCKET
     upload.settings.fuseki_base_url = TC.FUSEKI_URL
     upload.settings.fuseki_dataset = TC.FUSEKI_DATASET
 
@@ -223,7 +217,7 @@ def test_correct_path(mock_client):
     assert r.status_code == 200
     body = r.json()
     assert body["result"] == "success"
-    assert body["crate_url"] == f"{TC.MINIO_URL}/{TC.MINIO_BUCKET}/{TC.CRATE_ZIP}"
+    assert body["crate_url"] == f"http://{TC.SEAWEEDFS_FILER}/buckets/{TC.SEAWEEDFS_BUCKET}/{TC.CRATE_ZIP}"
 
 
 def test_upload_existing_result(mock_client, monkeypatch):
@@ -400,7 +394,7 @@ def test_get_crate_ok_with_content_type(monkeypatch):
 
     def mock_run_query(q):
         called["query"] = q
-        return [(f"{TC.MINIO_URL}/{TC.MINIO_BUCKET}/{TC.CRATE_ZIP}",)]
+        return [(f"http://{TC.SEAWEEDFS_FILER}/buckets/{TC.SEAWEEDFS_BUCKET}/{TC.CRATE_ZIP}",)]
 
     monkeypatch.setattr(get, "run_query", mock_run_query)
 
@@ -430,7 +424,7 @@ def test_get_crate_ok_with_content_type(monkeypatch):
 def test_get_crate_ok_defaults_content_type(monkeypatch):
     monkeypatch.setattr(get, "CRATE_URL_QUERY", "Q:%s")
     monkeypatch.setattr(get, "run_query",
-                        lambda q: [(f"{TC.MINIO_URL}/{TC.MINIO_BUCKET}/{TC.ANOTHER_ZIP}",)])
+                        lambda q: [(f"http://{TC.SEAWEEDFS_FILER}/buckets/{TC.SEAWEEDFS_BUCKET}/{TC.ANOTHER_ZIP}",)])
 
     class MockRespNoCT:
         def __init__(self):
@@ -473,7 +467,7 @@ def test_get_file_crate_not_found(monkeypatch):
 def test_get_file_ok_with_mapped_content_type(monkeypatch):
     monkeypatch.setattr(get, "CRATE_URL_QUERY", "Q:%s")
     monkeypatch.setattr(get, "run_query",
-                        lambda q: [(f"{TC.MINIO_URL}/{TC.MINIO_BUCKET}/{TC.CRATE_ZIP}",)])
+                        lambda q: [(f"http://{TC.SEAWEEDFS_FILER}/buckets/{TC.SEAWEEDFS_BUCKET}/{TC.CRATE_ZIP}",)])
     monkeypatch.setattr(get, "content_type_map", {"txt": TC.CONTENT_TYPE_PLAIN})
 
     zip_bytes = make_zip_bytes({"dir/file.txt": TC.FILE_CONTENT})
@@ -502,7 +496,7 @@ def test_get_file_ok_with_mapped_content_type(monkeypatch):
 def test_get_file_ok_default_content_type(monkeypatch):
     monkeypatch.setattr(get, "CRATE_URL_QUERY", "Q:%s")
     monkeypatch.setattr(get, "run_query",
-                        lambda q: [(f"{TC.MINIO_URL}/{TC.MINIO_BUCKET}/{TC.ANOTHER_ZIP}",)])
+                        lambda q: [(f"http://{TC.SEAWEEDFS_FILER}/buckets/{TC.SEAWEEDFS_BUCKET}/{TC.ANOTHER_ZIP}",)])
     monkeypatch.setattr(get, "content_type_map", {"txt": TC.CONTENT_TYPE_PLAIN})
 
     zip_bytes = make_zip_bytes({"x/y/file.dat": TC.BINARY_CONTENT})
@@ -531,7 +525,7 @@ def test_get_file_ok_default_content_type(monkeypatch):
 def test_get_file_member_missing(monkeypatch):
     monkeypatch.setattr(get, "CRATE_URL_QUERY", "Q:%s")
     monkeypatch.setattr(get, "run_query",
-                        lambda q: [(f"{TC.MINIO_URL}/{TC.MINIO_BUCKET}/miss.zip",)])
+                        lambda q: [(f"http://{TC.SEAWEEDFS_FILER}/buckets/{TC.SEAWEEDFS_BUCKET}/miss.zip",)])
 
     zip_bytes = make_zip_bytes({"dir/other.txt": b"nope"})
 
@@ -811,7 +805,7 @@ def test_cpmv_ok(monkeypatch, op):
 
     monkeypatch.setattr(pathops, "load_crate_metadata", mock_load_crate_metadata)
 
-    crate_url = "http://minio:9000/crates/foo.zip"
+    crate_url = f"http://{TC.SEAWEEDFS_FILER}/buckets/{TC.SEAWEEDFS_BUCKET}/foo.zip"
     monkeypatch.setattr(pathops, "movechain", lambda p: {"result": []})
     r = client.post(
         "/pathops/move/",


### PR DESCRIPTION
Changes the RO-Crate store to [SeaweedFS](https://github.com/seaweedfs/seaweedfs). Python interaction is now via [boto3](https://pypi.org/project/boto3/).