### PR TITLE
Repeatable cp / mv tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,5 +38,7 @@ jobs:
         pip install pytest
         sleep 5
         pytest -sv tests
+        # run again to check that the test dataset has not been altered by mv
+        pytest -sv tests
     - name: Docker teardown
       run: docker compose down -v

--- a/src/provstor_api/routes/pathops.py
+++ b/src/provstor_api/routes/pathops.py
@@ -65,10 +65,9 @@ async def _copy_or_move(src: str, dest: str, when: datetime = None, op="cp"):
     qres = run_query(IS_FILE_OR_DIR_QUERY % src)
     if len(qres) < 1:
         raise HTTPException(status_code=404, detail=f"File or Dataset '{src}' not found")
-    if op == "mv":
-        chain = movechain(src)["result"]
-        if chain:
-            raise HTTPException(status_code=422, detail=f"'{src}' has already been moved to: {chain}")
+    chain = movechain(src)["result"]
+    if chain:
+        raise HTTPException(status_code=422, detail=f"'{src}' has already been moved to: {chain}")
     qres = run_query(FILEINFO_QUERY % src)
     kwargs = {"when": when}
     if len(qres) >= 1:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,19 +39,28 @@ def data_dir():
 @pytest.fixture(scope="session")
 def crate_map(data_dir):
     m = {}
-    api_url = F"http://{API_HOST}:{API_PORT}/upload/crate/"
+    base_api_url = f"http://{API_HOST}:{API_PORT}"
     tmp_dir = Path(tempfile.mkdtemp(prefix="provstor_"))
     atexit.register(shutil.rmtree, tmp_dir)
+    response = requests.get(f"{base_api_url}/query/list-graphs/")
+    response.raise_for_status()
+    existing_crates = {_.rsplit("/", 1)[-1]: _ for _ in response.json()["result"]}
     for c in ["crate1", "crate2", "provcrate1", "proccrate1", "proccrate2"]:
+        crate_name = f"{c}.zip"
         crate_path = data_dir / c
-        zip_path = shutil.make_archive(tmp_dir / crate_path.name, 'zip', crate_path)
-        crate_name = Path(zip_path).name
-        with open(zip_path, 'rb') as crate_file:
-            response = requests.post(api_url, files={'crate_path': (crate_name, crate_file, 'application/zip')})
-        if response.status_code == 200 and response.json().get('result') == "success":
-            crate_url = response.json().get('crate_url')
+        if crate_name not in existing_crates:
+            zip_path = shutil.make_archive(tmp_dir / crate_name, 'zip', crate_path)
+            with open(zip_path, 'rb') as crate_file:
+                response = requests.post(
+                    f"{base_api_url}/upload/crate/",
+                    files={'crate_path': (crate_name, crate_file, 'application/zip')}
+                )
+            if response.status_code == 200 and response.json().get('result') == "success":
+                crate_url = response.json().get('crate_url')
+            else:
+                response.raise_for_status()
         else:
-            response.raise_for_status()
+            crate_url = existing_crates[crate_name]
         m[c] = {
             "path": crate_path,
             "url": crate_url,

--- a/tests/test_api_unit.py
+++ b/tests/test_api_unit.py
@@ -772,12 +772,13 @@ def test_cpmv_missing_src(monkeypatch, op):
     assert r.json()["detail"] == f"File or Dataset '{TC.FILE_URI_A}' not found"
 
 
-def test_mv_already_moved(monkeypatch):
+@pytest.mark.parametrize("op", ["copy", "move"])
+def test_cpmv_already_moved(monkeypatch, op):
     chain = ["file:///foo"]
     monkeypatch.setattr(pathops, "movechain", lambda p: {"result": chain})
     monkeypatch.setattr(pathops, "run_query", lambda q: [(URIRef(TC.FILE_URI_A),)])
     r = client.post(
-        "/pathops/move/",
+        f"/pathops/{op}/",
         params={
             "src": TC.FILE_URI_A,
             "dest": TC.FILE_URI_B,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -412,12 +412,20 @@ def test_cli_backtrack(crate_map):
 
 def test_cli_mv(crate_map):
     src = "file:///path/to/FOOBAR123.deepvariant.ann.norm.vcf.gz"
-    dest = "file:///a/b/FOOBAR123.deepvariant.ann.norm.vcf.gz"
+    # copy to a randomly named path so we don't alter the test data
+    src_copy = f"file:///{str(uuid.uuid4())}/FOOBAR123.deepvariant.ann.norm.vcf.gz"
     runner = CliRunner()
-    args = ["mv", src, dest]
+    args = ["cp", src, src_copy]
     result = runner.invoke(cli, args)
     assert result.exit_code == 0, result.exception
 
+    dest = f"file:///{str(uuid.uuid4())}/FOOBAR123.deepvariant.ann.norm.vcf.gz"
+    runner = CliRunner()
+    args = ["mv", src_copy, dest]
+    result = runner.invoke(cli, args)
+    assert result.exit_code == 0, result.exception
+
+    # does not start with "file:/"
     bad_src = "arcp://uuid,9498d061-370c-53cb-a1ce-a575c5c76f64/"
     args = ["mv", bad_src, dest]
     result = runner.invoke(cli, args)
@@ -429,12 +437,18 @@ def test_cli_mv(crate_map):
     assert result.exit_code != 0
 
     d_src = "file:///path/to/logs"
-    d_dest = "file:///a/b/logs"
-    args = ["mv", d_src, d_dest]
+    # copy to a randomly named path so we don't alter the test data
+    d_src_copy = f"file:///{str(uuid.uuid4())}/logs"
+    args = ["cp", d_src, d_src_copy]
     result = runner.invoke(cli, args)
     assert result.exit_code == 0, result.exception
 
-    dest2 = "file:///b/c/FOOBAR123.deepvariant.ann.norm.vcf.gz"
+    d_dest = f"file:///{str(uuid.uuid4())}/logs"
+    args = ["mv", d_src_copy, d_dest]
+    result = runner.invoke(cli, args)
+    assert result.exit_code == 0, result.exception
+
+    dest2 = f"file:///{str(uuid.uuid4())}/FOOBAR123.deepvariant.ann.norm.vcf.gz"
     args = ["mv", dest, dest2, "--when", "2025-10-10T08:05:00Z"]
     result = runner.invoke(cli, args)
     assert result.exit_code == 0, result.exception
@@ -444,31 +458,28 @@ def test_cli_mv(crate_map):
     result = runner.invoke(cli, args)
     assert result.exit_code != 0
 
-    args = ["movechain", src]
+    args = ["movechain", src_copy]
     result = runner.invoke(cli, args)
     assert result.exit_code == 0, result.exception
     lines = result.stdout.splitlines()
-    assert len(lines) >= 2
-    assert lines[:2] == [
-        "file:///a/b/FOOBAR123.deepvariant.ann.norm.vcf.gz",
-        "file:///b/c/FOOBAR123.deepvariant.ann.norm.vcf.gz",
-    ]
+    assert lines == [dest, dest2]
 
 
 def test_cli_cp(crate_map):
     src = "file:///path/to/FOOBAR123.deepvariant.ann.norm.vcf.gz"
-    dest = "file:///cp1/FOOBAR123.deepvariant.ann.norm.vcf.gz"
+    dest = f"file:///{str(uuid.uuid4())}/FOOBAR123.deepvariant.ann.norm.vcf.gz"
     runner = CliRunner()
     args = ["cp", src, dest]
     result = runner.invoke(cli, args)
     assert result.exit_code == 0, result.exception
 
-    dest2 = "file:///cp2/FOOBAR123.deepvariant.ann.norm.vcf.gz"
+    dest2 = f"file:///{str(uuid.uuid4())}/FOOBAR123.deepvariant.ann.norm.vcf.gz"
     runner = CliRunner()
     args = ["cp", src, dest2]
     result = runner.invoke(cli, args)
     assert result.exit_code == 0, result.exception
 
+    # does not start with "file:/"
     bad_src = "arcp://uuid,9498d061-370c-53cb-a1ce-a575c5c76f64/"
     args = ["cp", bad_src, dest]
     result = runner.invoke(cli, args)
@@ -480,7 +491,7 @@ def test_cli_cp(crate_map):
     assert result.exit_code != 0
 
     d_src = "file:///path/to/logs"
-    d_dest = "file:///cp1/logs"
+    d_dest = f"file:///{str(uuid.uuid4())}/logs"
     args = ["cp", d_src, d_dest]
     result = runner.invoke(cli, args)
     assert result.exit_code == 0, result.exception

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -410,6 +410,43 @@ def test_cli_backtrack(crate_map):
     }
 
 
+def test_cli_cp(crate_map):
+    src = "file:///path/to/FOOBAR123.deepvariant.ann.norm.vcf.gz"
+    dest = f"file:///{str(uuid.uuid4())}/FOOBAR123.deepvariant.ann.norm.vcf.gz"
+    runner = CliRunner()
+    args = ["cp", src, dest]
+    result = runner.invoke(cli, args)
+    assert result.exit_code == 0, result.exception
+
+    dest2 = f"file:///{str(uuid.uuid4())}/FOOBAR123.deepvariant.ann.norm.vcf.gz"
+    runner = CliRunner()
+    args = ["cp", src, dest2]
+    result = runner.invoke(cli, args)
+    assert result.exit_code == 0, result.exception
+
+    # does not start with "file:/"
+    bad_src = "arcp://uuid,9498d061-370c-53cb-a1ce-a575c5c76f64/"
+    args = ["cp", bad_src, dest]
+    result = runner.invoke(cli, args)
+    assert result.exit_code != 0
+
+    missing_src = f"file:///{str(uuid.uuid4())}"
+    args = ["cp", missing_src, dest]
+    result = runner.invoke(cli, args)
+    assert result.exit_code != 0
+
+    d_src = "file:///path/to/logs"
+    d_dest = f"file:///{str(uuid.uuid4())}/logs"
+    args = ["cp", d_src, d_dest]
+    result = runner.invoke(cli, args)
+    assert result.exit_code == 0, result.exception
+
+    future_date = "9999-10-10T08:05:00Z"
+    args = ["cp", src, "file:///q", "--when", future_date]
+    result = runner.invoke(cli, args)
+    assert result.exit_code != 0
+
+
 def test_cli_mv(crate_map):
     src = "file:///path/to/FOOBAR123.deepvariant.ann.norm.vcf.gz"
     # copy to a randomly named path so we don't alter the test data
@@ -463,40 +500,3 @@ def test_cli_mv(crate_map):
     assert result.exit_code == 0, result.exception
     lines = result.stdout.splitlines()
     assert lines == [dest, dest2]
-
-
-def test_cli_cp(crate_map):
-    src = "file:///path/to/FOOBAR123.deepvariant.ann.norm.vcf.gz"
-    dest = f"file:///{str(uuid.uuid4())}/FOOBAR123.deepvariant.ann.norm.vcf.gz"
-    runner = CliRunner()
-    args = ["cp", src, dest]
-    result = runner.invoke(cli, args)
-    assert result.exit_code == 0, result.exception
-
-    dest2 = f"file:///{str(uuid.uuid4())}/FOOBAR123.deepvariant.ann.norm.vcf.gz"
-    runner = CliRunner()
-    args = ["cp", src, dest2]
-    result = runner.invoke(cli, args)
-    assert result.exit_code == 0, result.exception
-
-    # does not start with "file:/"
-    bad_src = "arcp://uuid,9498d061-370c-53cb-a1ce-a575c5c76f64/"
-    args = ["cp", bad_src, dest]
-    result = runner.invoke(cli, args)
-    assert result.exit_code != 0
-
-    missing_src = f"file:///{str(uuid.uuid4())}"
-    args = ["cp", missing_src, dest]
-    result = runner.invoke(cli, args)
-    assert result.exit_code != 0
-
-    d_src = "file:///path/to/logs"
-    d_dest = f"file:///{str(uuid.uuid4())}/logs"
-    args = ["cp", d_src, d_dest]
-    result = runner.invoke(cli, args)
-    assert result.exit_code == 0, result.exception
-
-    future_date = "9999-10-10T08:05:00Z"
-    args = ["cp", src, "file:///q", "--when", future_date]
-    result = runner.invoke(cli, args)
-    assert result.exit_code != 0


### PR DESCRIPTION
Changes `cp` and `mv` tests to use randomly generated destination names, to avoid clashes if tests are run again. For the same reason, changes `crate_map` in `conftest.py` to avoid reuploading existing test crates.

Also fixes `cp`, adding a check that the source has not been moved, just like in `mv`.